### PR TITLE
Use safer limit for blocking timeout adjustments

### DIFF
--- a/handlers/blocker.go
+++ b/handlers/blocker.go
@@ -243,7 +243,7 @@ func (bc *blockingCommand) adjust() bool {
 	elapsed := time.Since(bc.start)
 	adjusted := bc.timeout - elapsed
 
-	if adjusted.Seconds() <= 0 {
+	if adjusted.Seconds() < 0.1 {
 		return true
 	}
 


### PR DESCRIPTION
We adjust a blocking command's timeout (embedded in the command itself) by subtracting however long the command has already been sitting in the blocker queue. The intent behind this is to approximately respect the initial timeout from the client's perspective, not the upstream's perspective.

In most cases, this worked well. Except in a small, but inevitable, edge case in which the timeout was adjusted to something smaller than the permissible precision for blocking timeouts:`BRPOPLPUSH a b 0.002` works fine, but `BRPOPLPUSH a b 0.001` is rounded to `BRPOPLPUSH a b 0`, which signals no timeout and that the command should block indefinitely. In this edge case, the command is sent to the upstream and blocks forever (or until an item lands in the source queue). In sparse queues, we arrive at this quickly and clients (which *are* expecting the command to timeout) will timeout shortly after.

As such, we can simply round up the limit for considering a command timed out from 0 to 0.1 seconds (fortunately, redis timeouts are already rather fuzzy). Local demonstrated that this works well.