### PR TITLE
Fix Linting Errors

### DIFF
--- a/handlers/blocker.go
+++ b/handlers/blocker.go
@@ -40,7 +40,6 @@ type blocker struct {
 	kill     chan interface{} // global kill
 
 	source       string
-	init         []*redis.Message
 	log          *zap.Logger
 	readTimeout  time.Duration
 	writeTimeout time.Duration
@@ -49,7 +48,7 @@ type blocker struct {
 	closed  bool
 }
 
-var upstreamDisconnectedErr = errors.New("upstream disconnected")
+var errUpstreamDisconnected = errors.New("upstream disconnected")
 
 func handleBlocker(c *connection, wm []*redis.Message) error {
 	c.reservations.Lock()
@@ -205,9 +204,11 @@ func (b *blocker) dequeue() {
 			b.log.Debug("Local connection was closed")
 		} else if cmd.adjust() {
 			b.log.Debug("blocking command timeout exceeded")
-			b.localWrite(cmd.local, []*redis.Message{redis.NewArray(nil)})
+			if err := b.localWrite(cmd.local, []*redis.Message{redis.NewArray(nil)}); err != nil {
+				b.log.Error("local write error", zap.Error(err))
+			}
 		} else if err := b.roundTrip(cmd); err != nil {
-			if errors.Is(err, upstreamDisconnectedErr) {
+			if errors.Is(err, errUpstreamDisconnected) {
 				// When we see the upstream disconnected we want to break out of the loop and close the blocker +
 				// all local connections to simulate what the client would see if they were talking directly
 				// to the upstream.
@@ -327,7 +328,7 @@ func (b *blocker) roundTrip(cmd *blockingCommand) error {
 	res, err := b.upstreamRead(b.readTimeout)
 	if err != nil {
 		if errors.Is(err, io.EOF) {
-			return upstreamDisconnectedErr
+			return errUpstreamDisconnected
 		}
 
 		return fmt.Errorf("upstream read: %w", err)
@@ -336,7 +337,9 @@ func (b *blocker) roundTrip(cmd *blockingCommand) error {
 	if isClusterResponse(res) {
 		err = fmt.Errorf("blocking commands aren't supported for Redis cluster")
 		mm := []*redis.Message{redis.NewError([]byte(fmt.Sprintf("redisbetween: %v", err.Error())))}
-		b.localWrite(cmd.local, mm)
+		if err := b.localWrite(cmd.local, mm); err != nil {
+			b.log.Error("local write error", zap.Error(err))
+		}
 
 		return err
 	}

--- a/handlers/blocker.go
+++ b/handlers/blocker.go
@@ -307,7 +307,9 @@ func (b *blocker) close() {
 
 		for i := range b.queue {
 			local := b.queue[i].local
-			local.Close()
+			if err := local.Close(); err != nil {
+				b.log.Warn("Could not close local connection", zap.Error(err))
+			}
 
 			b.parent.monitor.decrementLocalBlockers(
 				"reservation_event.local_unblock",

--- a/handlers/blocker_internal_test.go
+++ b/handlers/blocker_internal_test.go
@@ -234,10 +234,14 @@ func TestUpstreamDisconnect(t *testing.T) {
 	msgr.readErr = io.EOF
 
 	// Send blocking messages
-	handleBlocker(conns[0], getDefaultBlockerMessage())
-	handleBlocker(conns[1], getDefaultBlockerMessage())
-	handleBlocker(conns[2], getDefaultBlockerMessage())
-	handleBlocker(conns[3], getDefaultBlockerMessage())
+	err := handleBlocker(conns[0], getDefaultBlockerMessage())
+	assert.NoError(t, err)
+	err = handleBlocker(conns[1], getDefaultBlockerMessage())
+	assert.NoError(t, err)
+	err = handleBlocker(conns[2], getDefaultBlockerMessage())
+	assert.NoError(t, err)
+	err = handleBlocker(conns[3], getDefaultBlockerMessage())
+	assert.NoError(t, err)
 	bl := rs.get("b", "default").(*blocker)
 
 	for !isClosed(bl) {
@@ -266,7 +270,8 @@ func TestClusteredRedis(t *testing.T) {
 	}
 
 	// Send blocking messages and wait for the blocker to close
-	handleBlocker(conns[0], getDefaultBlockerMessage())
+	err := handleBlocker(conns[0], getDefaultBlockerMessage())
+	assert.NoError(t, err)
 	bl := rs.get("b", "default").(*blocker)
 	for !isClosed(bl) {
 		time.Sleep(10 * time.Millisecond)

--- a/handlers/mocks.go
+++ b/handlers/mocks.go
@@ -38,7 +38,7 @@ func (m *connWrapperMock) Return() error {
 }
 
 func (m *connWrapperMock) Alive() bool {
-	return m.closed == false
+	return !m.closed
 }
 
 func (m *connWrapperMock) ID() uint64 {

--- a/handlers/reservation.go
+++ b/handlers/reservation.go
@@ -81,7 +81,7 @@ func (r *Reservations) add(prefix string, source string, res reservation) error 
 	}
 
 	_, ok := r.list[key]
-	if !ok {
+	if ok {
 		return reservationError{key: key}
 	}
 

--- a/handlers/reservation.go
+++ b/handlers/reservation.go
@@ -80,12 +80,12 @@ func (r *Reservations) add(prefix string, source string, res reservation) error 
 		return fmt.Errorf("reservations are closed: %s", key)
 	}
 
-	if _, ok := r.list[key]; ok {
+	_, ok := r.list[key]
+	if !ok {
 		return reservationError{key: key}
-	} else {
-		r.list[key] = res
 	}
 
+	r.list[key] = res
 	return nil
 }
 
@@ -102,12 +102,12 @@ func (r *Reservations) get(prefix string, source string) reservation {
 func (r *Reservations) delete(prefix string, source string) error {
 	key := fmt.Sprintf("%s:%s", prefix, source)
 
-	if _, ok := r.list[key]; ok {
-		delete(r.list, key)
-	} else {
+	_, ok := r.list[key]
+	if !ok {
 		return fmt.Errorf("reservation with key '%s' does not exist", key)
 	}
 
+	delete(r.list, key)
 	return nil
 }
 

--- a/handlers/subscription.go
+++ b/handlers/subscription.go
@@ -254,7 +254,7 @@ func (s *subscription) broadcast() {
 			}
 		}
 
-		if wm != nil && len(wm) > 0 {
+		if len(wm) > 0 {
 			s.Lock()
 			s.log.Debug(
 				"Writing message to subscribers",

--- a/handlers/subscription.go
+++ b/handlers/subscription.go
@@ -174,7 +174,10 @@ func (s *subscription) close() {
 			[]string{fmt.Sprintf("channel:%s", s.channels)})
 
 		for _, local := range s.locals {
-			local.Close()
+			if err := local.Close(); err != nil {
+				s.log.Warn("Could not close local connection", zap.Error(err))
+			}
+
 			s.parent.monitor.decrementLocalSubscriptions(
 				"reservation_event.local_unsubscribe",
 				[]string{fmt.Sprintf("channel:%s", s.channels)})

--- a/handlers/subscription_internal_test.go
+++ b/handlers/subscription_internal_test.go
@@ -116,8 +116,10 @@ func TestBroadcastMessage(t *testing.T) {
 
 	// Subscribe. Once these are subscribed they'll start reading messages off of the mock messenger
 	// and writing the fake messages to the locals.
-	handleSubscription(conns[0], wm)
-	handleSubscription(conns[1], wm)
+	err := handleSubscription(conns[0], wm)
+	assert.NoError(t, err)
+	err = handleSubscription(conns[1], wm)
+	assert.NoError(t, err)
 	sub := rs.get("c", testChannelName).(*subscription)
 	defer sub.close()
 
@@ -142,15 +144,18 @@ func TestUnsubscribeLocal(t *testing.T) {
 	msgr.response = nil
 
 	// Subscribe
-	handleSubscription(conns[0], subMsg)
-	handleSubscription(conns[1], subMsg)
+	err := handleSubscription(conns[0], subMsg)
+	assert.NoError(t, err)
+	err = handleSubscription(conns[1], subMsg)
+	assert.NoError(t, err)
 	sub := rs.get("c", testChannelName).(*subscription)
 	sub.init = unsubMsg
 	defer sub.close()
 
 	// Unsubscribe 1 local
 	assert.Equal(t, 2, len(sub.locals))
-	sub.unsubscribe(conns[0], nil)
+	err = sub.unsubscribe(conns[0], nil)
+	assert.NoError(t, err)
 	assert.Equal(t, 1, len(sub.locals))
 
 	// Ensure unsubscribe message was written to local
@@ -175,15 +180,19 @@ func TestUnsubscribeUpstream(t *testing.T) {
 	msgr.response = nil
 
 	// Subscribe
-	handleSubscription(conns[0], wm)
-	handleSubscription(conns[1], wm)
+	err := handleSubscription(conns[0], wm)
+	assert.NoError(t, err)
+	err = handleSubscription(conns[1], wm)
+	assert.NoError(t, err)
 	sub := rs.get("c", testChannelName).(*subscription)
 
 	// Ensure upstream was returned to pool
 	unsubMsg := unsubscribeMessage(testChannelName)
 	assert.False(t, sm.connWrapperMock.returned)
-	sub.unsubscribe(conns[0], nil)
-	sub.unsubscribe(conns[1], unsubMsg)
+	err = sub.unsubscribe(conns[0], nil)
+	assert.NoError(t, err)
+	err = sub.unsubscribe(conns[1], unsubMsg)
+	assert.NoError(t, err)
 	assert.True(t, sm.connWrapperMock.returned)
 
 	// Ensure unsub message was sent to upstream

--- a/ruby/Gemfile.lock
+++ b/ruby/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    redisbetween (0.1.2)
+    redisbetween (0.2.2)
       redis
 
 GEM

--- a/ruby/lib/redisbetween/version.rb
+++ b/ruby/lib/redisbetween/version.rb
@@ -1,3 +1,3 @@
 module Redisbetween
-  VERSION = "0.1.2"
+  VERSION = "0.2.2"
 end


### PR DESCRIPTION
This fixes some linting and salus errors, most of which were around handling returned errors. It also bumps the ruby gem version to 0.2.2.