### PR TITLE
Expand env vars for int parameters

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"net/url"
 	"os"
+	"regexp"
 	"strconv"
 	"strings"
 	"time"
@@ -190,7 +191,9 @@ func getIntParam(v url.Values, key string, def int) int {
 	if !ok {
 		return def
 	}
-	i, err := strconv.Atoi(cl[0])
+
+	val := expandEnv(cl[0])
+	i, err := strconv.Atoi(val)
 	if err != nil {
 		return def
 	}
@@ -200,4 +203,11 @@ func getIntParam(v url.Values, key string, def int) int {
 func getBoolParam(v url.Values, key string) bool {
 	val := getStringParam(v, key, "false")
 	return val == "true"
+}
+
+func expandEnv(config string) string {
+	// more restrictive version of os.ExpandEnv that only replaces exact matches of ${ENV}
+	return regexp.MustCompile(`\${(\w+)}`).ReplaceAllStringFunc(config, func(s string) string {
+		return os.ExpandEnv(s)
+	})
 }

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -30,8 +30,11 @@ func TestParseFlags(t *testing.T) {
 		"-readtimeout", "1s",
 		"-writetimeout", "1s",
 		"redis://localhost:7000/0?minpoolsize=5&maxpoolsize=33&label=cluster1",
-		"redis://localhost:7002?minpoolsize=10&label=cluster2&readtimeout=3s&writetimeout=6s",
+		"redis://localhost:7002?minpoolsize=${TestParseFlags_MinPoolSize}&label=cluster2&readtimeout=3s&writetimeout=6s",
 	}
+
+	os.Setenv("TestParseFlags_MinPoolSize", "10")
+	defer os.Unsetenv("ENV_VAR")
 
 	resetFlags()
 	c, err := parseFlags()

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -33,8 +33,9 @@ func TestParseFlags(t *testing.T) {
 		"redis://localhost:7002?minpoolsize=${TestParseFlags_MinPoolSize}&label=cluster2&readtimeout=3s&writetimeout=6s",
 	}
 
-	os.Setenv("TestParseFlags_MinPoolSize", "10")
-	defer os.Unsetenv("ENV_VAR")
+	minPoolEnvVar := "TestParseFlags_MinPoolSize"
+	os.Setenv(minPoolEnvVar, "10")
+	defer os.Unsetenv(minPoolEnvVar)
 
 	resetFlags()
 	c, err := parseFlags()


### PR DESCRIPTION
This allows us to use environment variable names to configure integer settings.

I.E.
`redis://localhost:7002?minpoolsize=${MinPoolSize}&maxpoolsize=${MaxPoolSize}&maxblockers=${MAXBLCK}`

Copied from Mongobetween: https://github.com/coinbase/mongobetween/blob/master/config/config.go#L189