### PR TITLE
First version of server health check

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,7 +108,7 @@ Usage: bin/redisbetween [OPTIONS] uri1 [uri2] ...
   -healthcheckcycle
       number of seconds after which the healthcheck process should repeat itself (default 60s)
   -healthcheckthreshold
-      count of consecutive healtcheck failures after which a server is declared non-healthy 
+      count of consecutive healtcheck failures after which a server is declared non-healthy
 ```
 
 Each URI can specify the following settings as GET params:

--- a/README.md
+++ b/README.md
@@ -108,7 +108,7 @@ Usage: bin/redisbetween [OPTIONS] uri1 [uri2] ...
   -healthcheckcycle
       number of seconds after which the healthcheck process should repeat itself (default 60s)
   -healthcheckthreshold
-      count of consecutive healtcheck failures after which a server is declared non-healthy
+      count of consecutive healthcheck failures after which a server is declared unhealthy (default 3)
 ```
 
 Each URI can specify the following settings as GET params:

--- a/README.md
+++ b/README.md
@@ -103,6 +103,12 @@ Usage: bin/redisbetween [OPTIONS] uri1 [uri2] ...
     	statsd address (default "localhost:8125")
   -unlink
     	unlink existing unix sockets before listening
+  -healthcheck
+      start a background process to check the health of server connections
+  -healthcheckcycle
+      number of seconds after which the healthcheck process should repeat itself (default 60s)
+  -healthcheckthreshold
+      count of consecutive healtcheck failures after which a server is declared non-healthy 
 ```
 
 Each URI can specify the following settings as GET params:

--- a/config/config.go
+++ b/config/config.go
@@ -30,6 +30,7 @@ type Config struct {
 	Statsd                     string
 	Level                      zapcore.Level
 	Upstreams                  []Upstream
+	HealthCheck                bool
 	ServerHealthCheckSec       uint64
 	ServerHealthCheckThreshold uint64
 }
@@ -74,6 +75,7 @@ func parseFlags() (*Config, error) {
 
 	var network, localSocketPrefix, localSocketSuffix, stats, loglevel string
 	var pretty, unlink bool
+	var healthCheck bool
 	var healthCheckThreshold, healthCheckCycle uint64
 	flag.StringVar(&network, "network", "unix", "One of: tcp, tcp4, tcp6, unix or unixpacket")
 	flag.StringVar(&localSocketPrefix, "localsocketprefix", "/var/tmp/redisbetween-", "Prefix to use for unix socket filenames")
@@ -82,6 +84,7 @@ func parseFlags() (*Config, error) {
 	flag.StringVar(&stats, "statsd", defaultStatsdAddress, "Statsd address")
 	flag.BoolVar(&pretty, "pretty", false, "Pretty print logging")
 	flag.StringVar(&loglevel, "loglevel", "info", "One of: debug, info, warn, error, dpanic, panic, fatal")
+	flag.BoolVar(&healthCheck, "healthcheck", false, "Start the routine to do health checks on redis servers")
 	flag.Uint64Var(&healthCheckCycle, "healthcheckcycle", 60, "Integer value for the cycle during which server connections will be health-checked (sec); Must be bigger than healthcheckthreshold * 1sec; default: 60s")
 	flag.Uint64Var(&healthCheckThreshold, "healthcheckthreshold", 3, "The number of concecutive failures needed to declare a server connection dead; default: 3")
 
@@ -180,6 +183,7 @@ func parseFlags() (*Config, error) {
 		Pretty:                     pretty,
 		Statsd:                     stats,
 		Level:                      level,
+		HealthCheck:                healthCheck,
 		ServerHealthCheckThreshold: healthCheckThreshold,
 		ServerHealthCheckSec:       healthCheckCycle,
 	}, nil

--- a/proxy/proxy.go
+++ b/proxy/proxy.go
@@ -168,7 +168,9 @@ func (p *Proxy) run() error {
 	}
 	p.listenerLock.Unlock()
 
-	go p.checkConnections()
+	if p.config.HealthCheck {
+		go p.checkConnections()
+	}
 	return nil
 }
 

--- a/proxy/proxy.go
+++ b/proxy/proxy.go
@@ -444,10 +444,6 @@ func (p *Proxy) pingServer(s *pool.Server, m messenger.Messenger) bool {
 	return true
 }
 
-func (p *Proxy) isUpstreamHost(hostPort string) {
-
-}
-
 func connectWithInitCommand(command []byte, logWith *zap.Logger) pool.ConnectionOption {
 	co := pool.WithDialer(func(dialer pool.Dialer) pool.Dialer {
 		return pool.DialerFunc(func(ctx context.Context, network, address string) (net.Conn, error) {


### PR DESCRIPTION
When major changes happen to a cluster, `redis` clients (in Ruby) are not able to reconnect to the right set of servers. This is because `redisbetween` hangs on to the stale connections forever. 

- This change establishes a health check process that in the background will `PING` the remote servers, continually. If a server is not the `upstream config host` and is determined to be non-responsive that server will be removed from the list of `listeners`. The `listener` for the main upstream host (which was passed as the config endpoint at the start of redisbetween) will instead be re-created. After the recreation, the `listener` will have a better chance of connecting to the active IP address.

For non-clustered redis servers, this issue is less concerning but still can happen when the server is restarted (and assigned a new IP address). Recreation of the corresponding `Listener` should solve this problem.

- The `Proxy` also intercepts `CLUSTER NODES` commands and creates listeners for the newly found nodes. This routine is also enhanced to `remove` the listeners pointing to the old nodes.