### PR TITLE
[IM-8664] Fixing the healthcheck pong issue in Redisbetween

### DIFF
--- a/proxy/proxy.go
+++ b/proxy/proxy.go
@@ -465,17 +465,16 @@ func poolMonitor(sd *statsd.Client) *pool.Monitor {
 }
 
 // given an array of new nodes and an array of existing nodes it determines
-// which nodes don't exist and needs to be added; also which nodes are not longer a part of the cluster
+// which nodes don't exist and needs to be added; also which nodes are no longer a part of the cluster
 func compareNewNodesWithExisting(newNodes []string, existingNodes []string) (nodesToRemove, nodesToAdd []string) {
-	// convert to local socker addresses first
 	var newNodesMap = make(map[string]bool)
 	for _, node := range newNodes {
 		newNodesMap[node] = true
 	}
-	// compare with existing local addresses
+	// compare with existing nodes
 	for _, node := range existingNodes {
 		if _, ok := newNodesMap[node]; ok {
-			// remove it so we don't create a listener below
+      // duplicate: remove
 			delete(newNodesMap, node)
 			continue
 		}

--- a/proxy/proxy.go
+++ b/proxy/proxy.go
@@ -375,7 +375,6 @@ func (p *Proxy) healthCheckSingleConnection(key string, wg *sync.WaitGroup) {
 		if key == p.localConfigHost {
 			// add the upstream config host back; we always need to have that minimally
 			// but hopefully this time, the connection is re-established to the right IP
-			p.log.Warn("Server failed to respond; Recreating the listener for upstreamConfigHost", zap.String("server", key))
 			p.ensureListenerForUpstream(key, "")
 		}
 	}

--- a/proxy/proxy.go
+++ b/proxy/proxy.go
@@ -194,14 +194,15 @@ func (p *Proxy) interceptMessages(originalCmds []string, mm []*redis.Message) {
 		if originalCmds[i] == "CLUSTER NODES" {
 			if m.IsBulkBytes() {
 				lines := strings.Split(string(m.Value), "\n")
+				var hostPorts []string
 				for _, line := range lines {
 					lt := strings.IndexByte(line, ' ')
 					rt := strings.IndexByte(line, '@')
 					if lt > 0 && rt > 0 {
-						hostPort := line[lt+1 : rt]
-						p.ensureListenerForUpstream(hostPort, originalCmds[i])
+						hostPorts = append(hostPorts, line[lt+1:rt])
 					}
 				}
+				p.ensureNewListenersRemoveOld(hostPorts)
 			}
 		}
 
@@ -216,6 +217,41 @@ func (p *Proxy) interceptMessages(originalCmds []string, mm []*redis.Message) {
 				p.ensureListenerForUpstream(parts[2], originalCmds[i]+" "+parts[0])
 			}
 		}
+	}
+}
+
+// ensureNewListenersRemoveOld() creates new Listeners for nodes that didn't exist before
+// It also cleans up existing listeners for which no nodes exist anymore (with the exception of local config host)
+func (p *Proxy) ensureNewListenersRemoveOld(newNodes []string) {
+	// convert to local socker addresses first
+	fmt.Println(newNodes)
+	var newLocals = make(map[string]string)
+	for _, n := range newNodes {
+		local := localSocketPathFromUpstream(n, p.database, p.readonly, p.config.LocalSocketPrefix, p.config.LocalSocketSuffix)
+		newLocals[local] = n
+	}
+	func() {
+		p.listenerLock.Lock()
+		defer p.listenerLock.Unlock()
+		// compare with existing listeners; remove old listeners
+		for k, ls := range p.listeners {
+			if _, ok := newLocals[k]; ok {
+				// remove it so we don't create a listener below
+				delete(newLocals, k)
+				continue
+			}
+			// We don't want to remove this special host
+			if k == p.localConfigHost {
+				continue
+			}
+			p.log.Warn("Node not in new topology; Removing the listener", zap.String("node", k))
+			ls.Shutdown()
+			delete(p.listeners, k)
+		}
+	}()
+	// finally add the new ones
+	for _, v := range newLocals {
+		p.ensureListenerForUpstream(v, "CLUSTER NODES")
 	}
 }
 
@@ -312,6 +348,7 @@ func (p *Proxy) healthCheckConnections() {
 		time.Sleep(duration)
 		p.log.Debug("Just woke up to healthcheck connections")
 		keys := p.getListenerKeys()
+		fmt.Println(keys)
 		var wg sync.WaitGroup
 		for _, key := range keys {
 			wg.Add(1)
@@ -341,7 +378,7 @@ func (p *Proxy) healthCheckSingleConnection(key string, wg *sync.WaitGroup) {
 	healthy := true
 	for i := 0; i < int(p.config.ServerHealthCheckThreshold); i++ {
 		time.Sleep(1 * time.Second)
-		healthy = pingServer(p.config.Network, key, p.readTimeout, p.writeTimeout, p.log)
+		healthy = p.pingServer(key)
 		p.log.Debug("Finished pinging server", zap.String("server", key), zap.String("healthy", strconv.FormatBool(healthy)))
 		if healthy {
 			break
@@ -350,11 +387,14 @@ func (p *Proxy) healthCheckSingleConnection(key string, wg *sync.WaitGroup) {
 	if !healthy {
 		p.log.Warn("Server failed to respond; Deleting the listener", zap.String("server", key))
 		p.deleteListener(key)
-		p.getListener(key).Shutdown()
 		if key == p.localConfigHost {
 			// add the upstream config host back; we always need to have that minimally
 			// but hopefully this time, the connection is re-established to the right IP
+			p.log.Warn("Server failed to respond; Recreating the listener for upstreamConfigHost", zap.String("server", key))
 			p.ensureListenerForUpstream(key, "")
+		} else {
+			// Shutdown the old, failing listener if not the main one
+			p.getListener(key).Shutdown()
 		}
 	}
 }
@@ -386,6 +426,31 @@ func (p *Proxy) getListenerKeys() []string {
 		keys = append(keys, key)
 	}
 	return keys
+}
+
+// Use the redis PING command (response: PONG) to determine if the connection is healthy
+func (p *Proxy) pingServer(address string) bool {
+	dlr := &net.Dialer{Timeout: 30 * time.Second}
+	conn, err := dlr.DialContext(context.Background(), p.config.Network, address)
+	if err != nil {
+		p.log.Error("failed to open local address", zap.String("local", address), zap.Error(err))
+		return false
+	}
+	defer conn.Close()
+	conn.SetWriteDeadline(time.Now().Add(p.writeTimeout))
+	_, err = conn.Write([]byte(ping))
+	if err != nil {
+		p.log.Error("failed to write PING", zap.Error(err))
+		return false
+	}
+	conn.SetReadDeadline(time.Now().Add(p.readTimeout))
+	resp := make([]byte, 7)
+	_, err = io.ReadFull(conn, resp)
+	if err != nil || !strings.Contains(string(resp), pong) {
+		p.log.Error("expected PONG in response but got error", zap.String("response", string(resp)), zap.Error(err))
+		return false
+	}
+	return true
 }
 
 func connectWithInitCommand(command []byte, logWith *zap.Logger) pool.ConnectionOption {
@@ -439,35 +504,4 @@ func poolMonitor(sd *statsd.Client) *pool.Monitor {
 			}
 		},
 	}
-}
-
-// Use the redis PING command (response: PONG) to determine if the connection is healthy
-func pingServer(network, address string, readTimeout, writeTimeout time.Duration, logger *zap.Logger) bool {
-	dlr := &net.Dialer{Timeout: 30 * time.Second}
-	conn, err := dlr.DialContext(context.Background(), network, address)
-	if err != nil {
-		if logger != nil {
-			logger.Error("failed to open local address", zap.String("local", address), zap.Error(err))
-		}
-		return false
-	}
-	defer conn.Close()
-	conn.SetWriteDeadline(time.Now().Add(writeTimeout))
-	_, err = conn.Write([]byte(ping))
-	if err != nil {
-		if logger != nil {
-			logger.Error("failed to write PING", zap.Error(err))
-		}
-		return false
-	}
-	conn.SetReadDeadline(time.Now().Add(readTimeout))
-	resp := make([]byte, 7)
-	_, err = io.ReadFull(conn, resp)
-	if err != nil || !strings.Contains(string(resp), pong) {
-		if logger != nil {
-			logger.Error("expected PONG in response but got error", zap.String("response", string(resp)), zap.Error(err))
-		}
-		return false
-	}
-	return true
 }

--- a/proxy/proxy_test.go
+++ b/proxy/proxy_test.go
@@ -3,8 +3,10 @@ package proxy
 import (
 	"context"
 	"strconv"
+	"strings"
 	"sync"
 	"testing"
+	"time"
 
 	"github.com/coinbase/redisbetween/messenger"
 	"github.com/go-redis/redis/v8"
@@ -122,6 +124,33 @@ func TestLocalSocketPathFromUpstream(t *testing.T) {
 	assert.Equal(t, "prefix-withoutcolon.host.suffix", localSocketPathFromUpstream("withoutcolon.host", -1, false, "prefix-", ".suffix"))
 	assert.Equal(t, "prefix-with.host-db-1.suffix", localSocketPathFromUpstream("with.host:db", 1, false, "prefix-", ".suffix"))
 	assert.Equal(t, "prefix-with.host-db-ro.suffix", localSocketPathFromUpstream("with.host:db", -1, true, "prefix-", ".suffix"))
+}
+
+func TestPingServer(t *testing.T) {
+	shutdown := SetupProxy(t, "7000", -1)
+	network := "unix"
+	address := "/var/tmp/redisbetween-1-" + RedisHost() + "-7000.sock"
+	readTimeout := time.Second
+	writeTimeout := time.Second
+	assert.True(t, pingServer(network, address, readTimeout, writeTimeout, nil))
+	shutdown()
+}
+
+func TestNewNodeComparison(t *testing.T) {
+	toLocal := func(s string) string {
+		return strings.Replace(s, ":", "-", -1)
+	}
+	existingNodes := [3]string{"host1:port1", "host2:port2", "host3:port3"}
+	var existingLocals []string
+	for _, n := range existingNodes {
+		existingLocals = append(existingLocals, toLocal(n))
+	}
+	newNodes := [3]string{"host4:port4", "host2:port2", "host3:port3"}
+	tobeRemoved, tobeAdded := compareNewNodesWithExisting(newNodes[:], existingLocals, toLocal)
+	assert.Equal(t, 1, len(tobeAdded))
+	assert.Equal(t, 1, len(tobeRemoved))
+	assert.Equal(t, "host4:port4", tobeAdded[0])
+	assert.Equal(t, "host1-port1", tobeRemoved[0])
 }
 
 func assertResponse(t *testing.T, cmd command, c *redis.ClusterClient) {

--- a/proxy/proxy_test.go
+++ b/proxy/proxy_test.go
@@ -5,7 +5,6 @@ import (
 	"strconv"
 	"sync"
 	"testing"
-	"time"
 
 	"github.com/coinbase/redisbetween/messenger"
 	"github.com/go-redis/redis/v8"
@@ -123,16 +122,6 @@ func TestLocalSocketPathFromUpstream(t *testing.T) {
 	assert.Equal(t, "prefix-withoutcolon.host.suffix", localSocketPathFromUpstream("withoutcolon.host", -1, false, "prefix-", ".suffix"))
 	assert.Equal(t, "prefix-with.host-db-1.suffix", localSocketPathFromUpstream("with.host:db", 1, false, "prefix-", ".suffix"))
 	assert.Equal(t, "prefix-with.host-db-ro.suffix", localSocketPathFromUpstream("with.host:db", -1, true, "prefix-", ".suffix"))
-}
-
-func TestPingServer(t *testing.T) {
-	shutdown := SetupProxy(t, "7000", -1)
-	network := "unix"
-	address := "/var/tmp/redisbetween-1-" + RedisHost() + "-7000.sock"
-	readTimeout := time.Second
-	writeTimeout := time.Second
-	assert.True(t, pingServer(network, address, readTimeout, writeTimeout, nil))
-	shutdown()
 }
 
 func assertResponse(t *testing.T, cmd command, c *redis.ClusterClient) {

--- a/proxy/proxy_test.go
+++ b/proxy/proxy_test.go
@@ -3,7 +3,6 @@ package proxy
 import (
 	"context"
 	"strconv"
-	"strings"
 	"sync"
 	"testing"
 	"time"
@@ -137,20 +136,13 @@ func TestPingServer(t *testing.T) {
 }
 
 func TestNewNodeComparison(t *testing.T) {
-	toLocal := func(s string) string {
-		return strings.Replace(s, ":", "-", -1)
-	}
 	existingNodes := [3]string{"host1:port1", "host2:port2", "host3:port3"}
-	var existingLocals []string
-	for _, n := range existingNodes {
-		existingLocals = append(existingLocals, toLocal(n))
-	}
 	newNodes := [3]string{"host4:port4", "host2:port2", "host3:port3"}
-	tobeRemoved, tobeAdded := compareNewNodesWithExisting(newNodes[:], existingLocals, toLocal)
+	tobeRemoved, tobeAdded := compareNewNodesWithExisting(newNodes[:], existingNodes[:])
 	assert.Equal(t, 1, len(tobeAdded))
 	assert.Equal(t, 1, len(tobeRemoved))
 	assert.Equal(t, "host4:port4", tobeAdded[0])
-	assert.Equal(t, "host1-port1", tobeRemoved[0])
+	assert.Equal(t, "host1:port1", tobeRemoved[0])
 }
 
 func assertResponse(t *testing.T, cmd command, c *redis.ClusterClient) {

--- a/proxy/proxy_test.go
+++ b/proxy/proxy_test.go
@@ -5,6 +5,7 @@ import (
 	"strconv"
 	"sync"
 	"testing"
+	"time"
 
 	"github.com/coinbase/redisbetween/messenger"
 	"github.com/go-redis/redis/v8"
@@ -122,6 +123,16 @@ func TestLocalSocketPathFromUpstream(t *testing.T) {
 	assert.Equal(t, "prefix-withoutcolon.host.suffix", localSocketPathFromUpstream("withoutcolon.host", -1, false, "prefix-", ".suffix"))
 	assert.Equal(t, "prefix-with.host-db-1.suffix", localSocketPathFromUpstream("with.host:db", 1, false, "prefix-", ".suffix"))
 	assert.Equal(t, "prefix-with.host-db-ro.suffix", localSocketPathFromUpstream("with.host:db", -1, true, "prefix-", ".suffix"))
+}
+
+func TestPingServer(t *testing.T) {
+	shutdown := SetupProxy(t, "7000", -1)
+	network := "unix"
+	address := "/var/tmp/redisbetween-1-" + RedisHost() + "-7000.sock"
+	readTimeout := time.Second
+	writeTimeout := time.Second
+	assert.True(t, pingServer(network, address, readTimeout, writeTimeout, nil))
+	shutdown()
 }
 
 func assertResponse(t *testing.T, cmd command, c *redis.ClusterClient) {


### PR DESCRIPTION
When an error occurred in the previous version of `healthcheck`, the connection was returned back to the pool. This caused a problem where another client used the same connection to send their commands. If that happened the client would get a `PONG` back instead of intended response.

In this redesign, we avoided using the server connections directly and instead wrote to their corresponding Unix counterparts. The message and connection handling logic internal to Redisbetween would ensure that there is no message run over.

This redesign actually simplified the healthcheck changes too since we could make do with simpler data structures.
